### PR TITLE
test_sign: add batch file to test sign driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build*
+*.cer
+*.vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.0)
 
 project(WCD_driver)
 
+option(SIGN_DRIVER ON)
+option(CREATE_CERT OFF)
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /WX")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4 /WX")
 

--- a/WCD/CMakeLists.txt
+++ b/WCD/CMakeLists.txt
@@ -12,3 +12,21 @@ find_package(WDK REQUIRED)
 wdk_add_driver(WCD KMDF 1.15
         wcd.cpp
 	)
+
+if (CREATE_CERT)
+    set( CERTIFICATE_ARGS -r -pe -ss PrivateCertStore -n CN=TestCertificate.com TestCertificate.cer )
+    add_custom_command(TARGET WCD POST_BUILD
+        COMMAND MakeCert.exe ARGS ${CERTIFICATE_ARGS}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BIN_DIR}
+        COMMENT "Creating test certificate."
+)
+endif()
+
+if (SIGN_DRIVER)
+    set(SIGN_ARGS sign /v /a /s PrivateCertStore /n TestCertificate.com /fd SHA256 /t http://timestamp.digicert.com $<CONFIG>//WCD.sys )
+    add_custom_command(TARGET WCD POST_BUILD
+        COMMAND signtool.exe ARGS ${SIGN_ARGS}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BIN_DIR}
+        COMMENT "Signing driver with test certificate."
+)
+endif()

--- a/WCD/WCD.inf
+++ b/WCD/WCD.inf
@@ -7,7 +7,7 @@ Signature="$WINDOWS NT$"
 Class=System
 ClassGuid={4d36e97d-e325-11ce-bfc1-08002be10318}
 Provider=%ManufacturerName%
-DriverVer=
+DriverVer=19/05/2023,1.0.0.0
 CatalogFile=WCD.cat
 PnpLockdown=1
 
@@ -24,7 +24,7 @@ DefaultDestDir = 13
 
 
 [Manufacturer]
-%ManufacturerName%=Standard,NT$ARCH$
+%ManufacturerName%=Standard,NTAMD64
 
 [Standard.NT$ARCH$]
 

--- a/test_sign.bat
+++ b/test_sign.bat
@@ -1,0 +1,19 @@
+@echo off 
+IF "%1"=="/help" (
+    ECHO Execute the batch file to sign the WCD driver using TestCertificate. 
+    ECHO Add the flag /cert to create the test certificate.
+    GOTO end
+)
+
+IF "%1"=="/cert" (
+    ECHO Creating test certificate.
+    REM Creates test certificate to sign the driver
+    CALL "makecert /r /pe /ss PrivateCertStore /n CN=TestCertificate.com(Test) TestCertificate.cer"
+) ELSE (
+    ECHO Only signing operation.
+)
+
+REM Signs the driver with test certificate
+CALL signtool sign /v /a /s PrivateCertStore /n TestCertificate.com(Test) /fd SHA256 /t http://timestamp.digicert.com build\WCD\Debug\WCD.sys
+
+:end


### PR DESCRIPTION
Adds a batch file that can create a test certificate and sign the driver. We only need to create the test certificate once.
- No flags: Driver will be signed
- /cert Certificate will be created and driver signed.